### PR TITLE
Fixed bug in GameManager::movePlayer

### DIFF
--- a/core/src/com/tw/paintbots/GameManager.java
+++ b/core/src/com/tw/paintbots/GameManager.java
@@ -1111,7 +1111,7 @@ public class GameManager {
     Player player = players.get(player_idx);
     Vector2 move_dir = player.getDirection();
     // --- check for correct direction
-    if (move_dir.len2() < 0.00000001) {
+    if (move_dir.len2() < 0.00000001 || move_dir.len2() != move_dir.len2()) {
       System.out.println("Player " + player_idx
           + " returned direction with length 0 and is disqualified.");
       disqualifyPlayer(player);

--- a/core/src/com/tw/paintbots/GameManager.java
+++ b/core/src/com/tw/paintbots/GameManager.java
@@ -1115,6 +1115,7 @@ public class GameManager {
       System.out.println("Player " + player_idx
           + " returned direction with length 0 and is disqualified.");
       disqualifyPlayer(player);
+      hidePlayer(player);
       return;
     }
     // ---


### PR DESCRIPTION
There is a rare case where move_dir is NaN which caused other bugs. So I added a check for that and added hidePlayer on disqualification.

Code for bot that triggers the mentioned bug:
`  private float inc = -0.1f;`
myUpdate():
`dir.setAngleDeg(inc);`
`inc*=2f;`

Example bot as txt file because GitHub won't let me upload .java files.
[NaN_Bot.txt](https://github.com/Thomas-Wilde/PaintBots/files/8816055/NaN_Bot.txt)
